### PR TITLE
Feat: migrate to cryptography backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,16 @@
 This is an installer plugin for [certbot](https://certbot.eff.org). Whenever
 you generate a certificate with Let's Encrypt, it will save the certificate
 in a [PKCS#12](https://en.wikipedia.org/wiki/PKCS_12) archive.
+
+# Example
+
+## Installing PKCS#12
+`certbot install -i pkcs12 --pkcs12-location /etc/locationToPlaceFile.ptx`
+
+## Intergrating with other commands
+`certbot some_options --installer pkcs12 --pkcs12-location /path/to/your/pkcs12.pfx`
+
+This probably save your option in configuration files and will be applied in renewal
+:
+
+`certbot renew # auto install due to previous options`

--- a/README.md
+++ b/README.md
@@ -3,16 +3,3 @@
 This is an installer plugin for [certbot](https://certbot.eff.org). Whenever
 you generate a certificate with Let's Encrypt, it will save the certificate
 in a [PKCS#12](https://en.wikipedia.org/wiki/PKCS_12) archive.
-
-# Example
-
-## Installing PKCS#12
-`certbot install -i pkcs12 --pkcs12-location /etc/locationToPlaceFile.pfx`
-
-## Intergrating with other commands
-`certbot some_options --installer pkcs12 --pkcs12-location /path/to/your/pkcs12.p12`
-
-This probably save your option in configuration files and will be applied in renewal
-:
-
-`certbot renew # auto install will apply previous options`

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ in a [PKCS#12](https://en.wikipedia.org/wiki/PKCS_12) archive.
 # Example
 
 ## Installing PKCS#12
-`certbot install -i pkcs12 --pkcs12-location /etc/locationToPlaceFile.ptx`
+`certbot install -i pkcs12 --pkcs12-location /etc/locationToPlaceFile.pfx`
 
 ## Intergrating with other commands
-`certbot some_options --installer pkcs12 --pkcs12-location /path/to/your/pkcs12.pfx`
+`certbot some_options --installer pkcs12 --pkcs12-location /path/to/your/pkcs12.p12`
 
 This probably save your option in configuration files and will be applied in renewal
 :
 
-`certbot renew # auto install due to previous options`
+`certbot renew # auto install will apply previous options`

--- a/certbot_pkcs12.py
+++ b/certbot_pkcs12.py
@@ -22,10 +22,10 @@ def _load_cert(path):
 
 def _load_certs(path):
     delimiter = b'-----BEGIN CERTIFICATE-----\n'
-     for section in _load_bytes(path).split(delimiter):
-         section = section.strip()
-         if section:
-             yield load_pem_x509_certificate(delimiter + section)
+    for section in _load_bytes(path).split(delimiter):
+        section = section.strip()
+        if section:
+            yield load_pem_x509_certificate(delimiter + section)
 
 
 class Installer(common.Plugin, interfaces.Installer):

--- a/certbot_pkcs12.py
+++ b/certbot_pkcs12.py
@@ -2,7 +2,9 @@
 from certbot import interfaces
 from certbot.display import util as display_util
 from certbot.plugins import common
-from OpenSSL import crypto
+from cryptography.hazmat.primitives.serialization import NoEncryption, BestAvailableEncryption, load_pem_private_key
+from cryptography.hazmat.primitives.serialization.pkcs12 import serialize_key_and_certificates
+from cryptography.x509 import load_pem_x509_certificate
 
 
 def _load_bytes(path):
@@ -11,20 +13,20 @@ def _load_bytes(path):
 
 
 def _load_key(path):
-    return crypto.load_privatekey(crypto.FILETYPE_PEM, _load_bytes(path))
+    return load_pem_private_key(_load_bytes(path), password=None)
 
 
 def _load_cert(path):
-    return crypto.load_certificate(crypto.FILETYPE_PEM, _load_bytes(path))
+    return load_pem_x509_certificate(_load_bytes(path))
 
 
 def _load_certs(path):
-    delimiter = b'-----BEGIN CERTIFICATE-----\n'
-    for section in _load_bytes(path).split(delimiter):
-        section = section.strip()
-        if section:
-            yield crypto.load_certificate(
-                crypto.FILETYPE_PEM, delimiter + section)
+    with open(path, 'rb') as f:
+        delimiter = b'-----BEGIN CERTIFICATE-----\n'
+        for section in f.read().split(delimiter):
+            section = section.strip()
+            if section:
+                yield load_pem_x509_certificate(delimiter + section)
 
 
 class Installer(common.Plugin, interfaces.Installer):
@@ -52,15 +54,21 @@ class Installer(common.Plugin, interfaces.Installer):
         if passphrase is not None:
             passphrase = passphrase.encode()
 
-        pkcs12 = crypto.PKCS12()
-        pkcs12.set_privatekey(_load_key(key_path))
-        pkcs12.set_certificate(_load_cert(cert_path))
-        pkcs12.set_ca_certificates(_load_certs(chain_path))
-        out_bytes = pkcs12.export(passphrase=passphrase)
+        private_key = _load_key(key_path)
+        certificate = _load_cert(cert_path)
+        ca_certificates = _load_certs(chain_path)
+
+        pkcs12_data = serialize_key_and_certificates(
+            name=None,
+            key=private_key,
+            cert=certificate,
+            cas=ca_certificates,
+            encryption_algorithm=NoEncryption() if passphrase is None else BestAvailableEncryption(passphrase)
+        )
 
         location = self.conf('location')
         with open(location, 'wb') as f:
-            f.write(out_bytes)
+            f.write(pkcs12_data)
         display_util.notify(f'The PKCS#12 archive is stored at {location}.')
 
     def enhance(self, domain, enhancement, options=None):

--- a/certbot_pkcs12.py
+++ b/certbot_pkcs12.py
@@ -21,12 +21,11 @@ def _load_cert(path):
 
 
 def _load_certs(path):
-    with open(path, 'rb') as f:
-        delimiter = b'-----BEGIN CERTIFICATE-----\n'
-        for section in f.read().split(delimiter):
-            section = section.strip()
-            if section:
-                yield load_pem_x509_certificate(delimiter + section)
+    delimiter = b'-----BEGIN CERTIFICATE-----\n'
+     for section in _load_bytes(path).split(delimiter):
+         section = section.strip()
+         if section:
+             yield load_pem_x509_certificate(delimiter + section)
 
 
 class Installer(common.Plugin, interfaces.Installer):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "certbot >= 1.19.0",
-    "pyOpenSSL < 24.1.0",
+    "cryptography>=42.0.8",
 ]
 requires-python = ">=3.8"
 


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
`OpenSSL.crypto.PKCS12()` deprecated and finally removed since pyOpenSSL 24.1.0. This PR provides migration into cryptography backend.

# Related Issue(s)

Final solution of #2 

# Testing
```bash
sudo certbot some_options --installer pkcs12 --pkcs12-location /path/to/your/pkcs12.pfx
```
With pyOpenSSL>=24.1.0 and cryptography the command succeeded.
