### PR TITLE
Use hashes to reference third-party GitHub Actions workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   publish:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@d83bb11581e517f1e786ae76f146781fdd21cd2f  # v2.0.0
     secrets:
       pypi_token: ${{ secrets.pypi_token }}


### PR DESCRIPTION
This is a supply chain security best practice.